### PR TITLE
kmerR should use pvalR

### DIFF
--- a/kGWAS/src/KmerProjection_GLM.py
+++ b/kGWAS/src/KmerProjection_GLM.py
@@ -202,7 +202,7 @@ class KmerProjection(object):
                     if abs(correlation) > self.cor_threshold:
                         pvalR = self.getGLMpval(split[1], header)
                         if pvalR > self.pval_threshold:
-                            self.associationMatrix[kmerR] = [int(correlation*100),int(pvalF*100)]  
+                            self.associationMatrix[kmerR] = [int(correlation*100),int(pvalR*100)]  
                                         
         gz.close()
     


### PR DESCRIPTION
If only the reverse complement of a kmer is in the matrix, its currently using the pvalue from the last kmer analyzed, not the pvalue for kmerR.